### PR TITLE
Support for 32-bit windows and linux builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,13 @@ var AdmZip = require('adm-zip');
 var Promise = require('bluebird');
 
 var platform = os.platform();
+var arch = os.arch();
 
 var DOWNLOAD_MAC = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-macos.tar.gz';
-var DOWNLOAD_LINUX = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz';
-var DOWNLOAD_WIN = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-win64.zip';
+var DOWNLOAD_LINUX64 = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz';
+var DOWNLOAD_LINUX32 = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux32.tar.gz';
+var DOWNLOAD_WIN32 = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-win32.zip';
+var DOWNLOAD_WIN64 = 'https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-win64.zip';
 
 // TODO: move this to package.json or something
 var downloadUrl = DOWNLOAD_MAC;
@@ -20,11 +23,11 @@ var outFile = 'geckodriver.tar.gz';
 var executable = 'geckodriver';
 
 if (platform === 'linux') {
-  downloadUrl = DOWNLOAD_LINUX;
+  downloadUrl = arch === 'x64' ? DOWNLOAD_LINUX64 : DOWNLOAD_LINUX32;
 }
 
 if (platform === 'win32') {
-  downloadUrl = DOWNLOAD_WIN;
+  downloadUrl = arch === 'x64' ? DOWNLOAD_WIN64 : DOWNLOAD_WIN32;
   outFile = 'geckodriver.zip';
   executable = 'geckodriver.exe';
 }


### PR DESCRIPTION
I was getting a weird error running selenium on my windows VM, then I realised that geckodriver was a 64-bit executable running on my 32-bit OS (I tend to do that when the VM needs less than 4gb ram).

Mozilla release 32-bit versions of both linux and windows drivers, so it makes sense to download the correct one?

I've only actually tested the 32-bit codepath on windows but I did check the linux32 tarball had the right filename inside it. I also noted that nodejs has multiple 32-bit arch values but only one 64-bit so I structured the check to use 32-bit as a fallback if the arch isn't 64-bit.