### PR TITLE
Add support for a binary CDN location

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ profile.setPreference('marionette', true);
 // profile.setPreference('marionette.logging', 'TRACE');
 ```
 
+## Setting a CDN URL for binary download
+
+To set an alternate CDN location for geckodriver binaries, set the `GECKODRIVER_CDNURL` like this:
+
+```
+GECKODRIVER_CDNURL=https://INTERNAL_CDN/geckodriver/download
+```
+
+Binaries on your CDN should be located in a subdirectory of the above base URL. For example, `/vxx.xx.xx/*.tar.gz` should be located under `/geckodriver/download` above.
+
 ## Related Projects
 
 * [node-chromedriver](https://github.com/giggio/node-chromedriver)

--- a/index.js
+++ b/index.js
@@ -11,11 +11,16 @@ var Promise = require('bluebird');
 var platform = os.platform();
 var arch = os.arch();
 
-var DOWNLOAD_MAC = 'https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-macos.tar.gz';
-var DOWNLOAD_LINUX64 = 'https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz';
-var DOWNLOAD_LINUX32 = 'https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux32.tar.gz';
-var DOWNLOAD_WIN32 = 'https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-win32.zip';
-var DOWNLOAD_WIN64 = 'https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-win64.zip';
+var baseCDNURL = process.env.GECKODRIVER_CDNURL || 'https://github.com/mozilla/geckodriver/releases/download';
+
+// Remove trailing slash if included
+baseCDNURL = baseCDNURL.replace(/\/+$/, '');
+
+var DOWNLOAD_MAC = baseCDNURL + '/v0.17.0/geckodriver-v0.17.0-macos.tar.gz';
+var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz';
+var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.17.0/geckodriver-v0.17.0-linux32.tar.gz';
+var DOWNLOAD_WIN32 = baseCDNURL + '/v0.17.0/geckodriver-v0.17.0-win32.zip';
+var DOWNLOAD_WIN64 = baseCDNURL + '/v0.17.0/geckodriver-v0.17.0-win64.zip';
 
 // TODO: move this to package.json or something
 var downloadUrl = DOWNLOAD_MAC;


### PR DESCRIPTION
This PR adds a configuration option called `GECKODRIVER_CDNURL`, which is similar to the option `CHROMEDRIVER_CDNURL` in the `chromedriver` project.

Currently, when installing `geckodriver` on CI machines in a restricted corporate network such as the one we have at Walmart, `geckodriver` binary installation fails due to the assumption that github access is available.

This PR adds:

- Code which either uses the default or `GECKODRIVER_CDNURL` if present, with trailing slash stripping (similar to `chromedriver`'s convention).
- Update to README on how to configure the CDN option, what it's for, and where to place binaries on a CDN relative to the base URL.

/cc @vladikoff 