### PR TITLE
fix(url): Pass parsed url to got

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var os = require('os');
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 
 var got = require('got');
 var targz = require('tar.gz');
@@ -38,7 +39,7 @@ if (platform === 'win32') {
 }
 
 process.stdout.write('Downloading geckodriver... ');
-got.stream(downloadUrl)
+got.stream(url.parse(downloadUrl))
   .pipe(fs.createWriteStream(outFile))
   .on('close', function() {
     process.stdout.write('Extracting... ');


### PR DESCRIPTION
This allows for usage of things such as basic auth, and other features
that node's built-in url library support that `got` expects.

I only tested this by installing node-geckodriver via

```
GECKODRIVER_CDNURL="https://${ght}@github.com/mozilla/geckodriver/releases/download" npm link ../node-geckodriver/
```

and confirmed that it no longer threw the error present in the upstream
issue sindresorhus/got#184

```
Error: Basic authentication must be done with auth option                                                                                                      │$: git co master
    at normalizeArguments (~/code/project/node_modules/got/index.js:215:10)
```