### PR TITLE
add bin target w/.exe extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "main": "lib/geckodriver",
   "bin": {
-    "geckodriver": "./bin/geckodriver"
+    "geckodriver": "./bin/geckodriver",
+    "geckodriver.exe": "./bin/geckodriver"
   },
   "license": "MPL-2.0",
   "bugs": {


### PR DESCRIPTION
On Windows, as on other platforms, this package installs the ./bin/geckodriver script to a directory in PATH (which then runs the geckodriver.exe executable that gets downloaded to the package's directory). But the selenium-webdriver package expects to find a geckodriver.exe executable in the PATH on Windows:

https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/firefox/index.js#L296-L297

So it can't find the executable after I install it via this package.

This pull request is a hack that directs npm to install ./bin/geckodriver as geckodriver.exe as well. I'm not happy with this approach, since it happens on all three platforms rather than only on Windows. But it does solve the problem (and shouldn't cause problems on Mac/Linux).

An alternative might be to create this copy in the postinstall step, where we can test for platform.
