### PR TITLE
copy geckodriver.exe to npm bin dir on Windows (fixes #30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "main": "lib/geckodriver",
   "bin": {
-    "geckodriver": "./bin/geckodriver",
-    "geckodriver.exe": "./bin/geckodriver"
+    "geckodriver": "./bin/geckodriver"
   },
   "license": "MPL-2.0",
   "bugs": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,12 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    t.is(stdout, 'Downloading geckodriver... Extracting... Complete.\n');
+    if (process.platform() === 'win32') {
+      t.is(stdout, 'Downloading geckodriver... Extracting... Copying... Complete.\n');
+    }
+    else {
+      t.is(stdout, 'Downloading geckodriver... Extracting... Complete.\n');
+    }
     t.is(stderr, '');
     t.end();
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,13 @@
 import test from 'ava';
 import child_process from 'child_process';
+import os from 'os';
 
 test.cb('properly extracts', t => {
   child_process.exec('node ../index.js', (error, stdout, stderr) => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    if (process.platform() === 'win32') {
+    if (os.platform() === 'win32') {
       t.is(stdout, 'Downloading geckodriver... Extracting... Copying... Complete.\n');
     }
     else {


### PR DESCRIPTION
This branch copies geckodriver.exe to the NPM binary directory on Windows in order to make it available to selenium-webdriver. It's a better fix for the issue that I tried to fix in #29, which didn't actually fix the problem.

This only installs geckodriver.exe on Windows, and it does so by copying the file. It might make more sense to link it instead, unsure. I tried to add a preuninstall script to remove the file on uninstall, but NPM complains: "Refusing to delete C:\Users\myk\AppData\Roaming\npm\geckodriver.exe: is outside C:\Users\myk\AppData\Roaming\npm\node_modules\geckodriver and not a link"