### PR TITLE
document how to link geckodriver.exe manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ profile.setPreference('marionette', true);
 // profile.setPreference('marionette.logging', 'TRACE');
 ```
 
+### Use it globally:
+
+```
+npm install -g geckodriver
+geckodriver [args]
+```
+
+Note: This installs a `geckodriver` shell script that runs the executable, but on Windows, selenium-webdriver looks for `geckodriver.exe`. To use a global installation of this package with selenium-webdriver on Windows, copy or link `geckodriver.exe` to a location on your PATH (such as the NPM bin directory) after installing this package:
+
+```
+>mklink %USERPROFILE%\AppData\Roaming\npm\geckodriver.exe %USERPROFILE%\AppData\Roaming\npm\node_modules\geckodriver\geckodriver.exe
+```
+
 ## Setting a CDN URL for binary download
 
 To set an alternate CDN location for geckodriver binaries, set the `GECKODRIVER_CDNURL` like this:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ geckodriver [args]
 Note: This installs a `geckodriver` shell script that runs the executable, but on Windows, selenium-webdriver looks for `geckodriver.exe`. To use a global installation of this package with selenium-webdriver on Windows, copy or link `geckodriver.exe` to a location on your PATH (such as the NPM bin directory) after installing this package:
 
 ```
->mklink %USERPROFILE%\AppData\Roaming\npm\geckodriver.exe %USERPROFILE%\AppData\Roaming\npm\node_modules\geckodriver\geckodriver.exe
+mklink %USERPROFILE%\AppData\Roaming\npm\geckodriver.exe %USERPROFILE%\AppData\Roaming\npm\node_modules\geckodriver\geckodriver.exe
 ```
 
 ## Setting a CDN URL for binary download

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "main": "lib/geckodriver",
   "bin": {
-    "geckodriver": "./bin/geckodriver",
-    "geckodriver.exe": "./bin/geckodriver"
+    "geckodriver": "./bin/geckodriver"
   },
   "license": "MPL-2.0",
   "bugs": {


### PR DESCRIPTION
As I mentioned in #31, the fix for #29 didn't really solve the problem, and it doesn't look like there's an actual solution that doesn't itself cause more problems. So this branch reverts #29 and then documents how to manually link geckodriver.exe into your PATH on Windows.

Sorry for the churn. 😞 