### PR TITLE
Ability to use CDN URL in .npmrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ To set an alternate CDN location for geckodriver binaries, set the `GECKODRIVER_
 ```
 GECKODRIVER_CDNURL=https://INTERNAL_CDN/geckodriver/download
 ```
+Alternatively, you can add the property to your `.npmrc` as :
+```
+GECKODRIVER_CDNURL=https://INTERNAL_CDN/geckodriver/download
+```
+
+Default location is set to https://github.com/mozilla/geckodriver/releases/download
 
 Binaries on your CDN should be located in a subdirectory of the above base URL. For example, `/vxx.xx.xx/*.tar.gz` should be located under `/geckodriver/download` above.
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ var baseCDNURL = process.env.npm_config_geckodriver_cdnurl || process.env.GECKOD
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');
 
-  var DOWNLOAD_MAC = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-macos.tar.gz';
-  var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz';
-  var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux32.tar.gz';
-  var DOWNLOAD_WIN32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win32.zip';
-  var DOWNLOAD_WIN64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win64.zip';
+var DOWNLOAD_MAC = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-macos.tar.gz';
+var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz';
+var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux32.tar.gz';
+var DOWNLOAD_WIN32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win32.zip';
+var DOWNLOAD_WIN64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win64.zip';
 
 // TODO: move this to package.json or something
 var downloadUrl = DOWNLOAD_MAC;

--- a/index.js
+++ b/index.js
@@ -11,16 +11,16 @@ var Promise = require('bluebird');
 var platform = os.platform();
 var arch = os.arch();
 
-var baseCDNURL = process.env.GECKODRIVER_CDNURL || 'https://github.com/mozilla/geckodriver/releases/download';
+// order -> npmrc first, environment var second, defaults to github last.
+var baseCDNURL = process.env.npm_config_geckodriver_cdnurl || process.env.GECKODRIVER_CDNURL || 'https://github.com/mozilla/geckodriver/releases/download';
 
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');
-
-var DOWNLOAD_MAC = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-macos.tar.gz';
-var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz';
-var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux32.tar.gz';
-var DOWNLOAD_WIN32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win32.zip';
-var DOWNLOAD_WIN64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win64.zip';
+  var DOWNLOAD_MAC = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-macos.tar.gz';
+  var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz';
+  var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux32.tar.gz';
+  var DOWNLOAD_WIN32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win32.zip';
+  var DOWNLOAD_WIN64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-win64.zip';
 
 // TODO: move this to package.json or something
 var downloadUrl = DOWNLOAD_MAC;
@@ -38,11 +38,11 @@ if (platform === 'win32') {
   executable = 'geckodriver.exe';
 }
 
-process.stdout.write('Downloading geckodriver... ');
+process.stdout.write(`Downloading geckodriver from ${downloadUrl}...\n`);
 got.stream(downloadUrl)
   .pipe(fs.createWriteStream(outFile))
   .on('close', function() {
-    process.stdout.write('Extracting... ');
+    process.stdout.write(`Extracting ${outFile} to ${__dirname}...\n`);
     extract(path.join(__dirname, outFile), __dirname)
       .then(function(){
         console.log('Complete.');

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var baseCDNURL = process.env.npm_config_geckodriver_cdnurl || process.env.GECKOD
 
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');
+
   var DOWNLOAD_MAC = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-macos.tar.gz';
   var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz';
   var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.19.0/geckodriver-v0.19.0-linux32.tar.gz';

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,8 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    t.is(stdout, 'Downloading geckodriver... Extracting... Complete.\n');
+    let regx = 'Downloading geckodriver from (?:(http[s]?):\/\/)?([^:\/\s]+)(:[0-9]+)?((?:\/\w+)*\/)([\w\-\.]+[^#?\s]+)([^#\s]*)?(#[\w\-]+)? geckodriver.tar.gz to (\/*)(.*)(...)\/node-geckodriver...\\nComplete.\\n'
+    t.regex(stdout,  regx);
     t.is(stderr, '');
     t.end();
   });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    t.regex(stdout, /Downloading geckodriver from (.*)Extracting geckodriver.tar.gz to (*)...\nComplete.\n/);
+    t.regex(stdout, /Downloading geckodriver from (.*)Extracting geckodriver.tar.gz to (.*)...\nComplete.\n/);
     t.is(stderr, '');
     t.end();
   });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    t.is(stdout, 'Downloading geckodriver from https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz...\nExtracting geckodriver.tar.gz to /home/travis/build/vladikoff/node-geckodriver...\nComplete.\n');
+    t.regex(stdout, /Downloading geckodriver from (.*)Extracting geckodriver.tar.gz to (*)...\nComplete.\n/);
     t.is(stderr, '');
     t.end();
   });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    t.regex(stdout, /Downloading geckodriver from (.*)Extracting geckodriver.tar.gz to (.*)...\nComplete.\n/);
+    t.is(stdout, 'Downloading geckodriver... Extracting... Complete.\n');
     t.is(stderr, '');
     t.end();
   });

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,7 @@ test.cb('properly extracts', t => {
     if (error) {
       return t.fail(`exec error: ${error}`)
     }
-    let regx = 'Downloading geckodriver from (?:(http[s]?):\/\/)?([^:\/\s]+)(:[0-9]+)?((?:\/\w+)*\/)([\w\-\.]+[^#?\s]+)([^#\s]*)?(#[\w\-]+)? geckodriver.tar.gz to (\/*)(.*)(...)\/node-geckodriver...\\nComplete.\\n'
-    t.regex(stdout,  regx);
+    t.is(stdout, 'Downloading geckodriver from https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz...\nExtracting geckodriver.tar.gz to /home/travis/build/vladikoff/node-geckodriver...\nComplete.\n');
     t.is(stderr, '');
     t.end();
   });


### PR DESCRIPTION
Enhancements/Changes made -
- I added the ability to implement the CDN URL inside the .npmrc file similarly to how the chromedriver allows it.  
- Updated some of the console logs to be more descriptive during install.  
- Updated the README to provide an explanation of how the CDN URL can be used in the .npmrc file along with the default value if no CDN URL is provided.