### PR TITLE
Update adm-zip package version to 0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geckodriver",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Downloader for https://github.com/mozilla/geckodriver/releases",
   "scripts": {
     "test": "ava",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/vladikoff/node-geckodriver#readme",
   "dependencies": {
-    "adm-zip": "0.4.7",
+    "adm-zip": "0.4.11",
     "bluebird": "3.4.6",
     "got": "5.6.0",
     "tar": "4.0.2"


### PR DESCRIPTION
adm-zip npm library before 0.4.11 is vulnerable to directory traversal, allowing attackers to write to arbitrary file...

https://nvd.nist.gov/vuln/detail/CVE-2018-1002204