### PR TITLE
Fetch latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.tar.gz
 *.log
 yarn.lock
+lib/version

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 !/*/geckodriver
 *.tar.gz
 *.log
+yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "singleQuote": true
+}

--- a/bin/geckodriver
+++ b/bin/geckodriver
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
-var path = require('path')
-var execPath = require(path.join(__dirname, '..', 'lib', 'geckodriver')).path
-var cp = require('child_process').spawn(execPath, process.argv.slice(2), {stdio: 'inherit'})
-cp.on('exit', process.exit)
+var path = require('path');
+var execPath = require(path.join(__dirname, '..', 'lib', 'geckodriver')).path;
+var cp = require('child_process').spawn(execPath, process.argv.slice(2), {
+  stdio: 'inherit',
+});
+cp.on('exit', process.exit);
 process.on('SIGTERM', function() {
-  cp.kill('SIGTERM')
-  process.exit(1)
-})
+  cp.kill('SIGTERM');
+  process.exit(1);
+});

--- a/index.js
+++ b/index.js
@@ -39,8 +39,13 @@ async function fetchLatestVersionNumber() {
   } catch (error) {}
 }
 
+function storeVersionNumber() {
+  fs.writeFileSync(path.join(__dirname, 'lib', 'version'), latestVersion);
+}
+
 function setVariables() {
-  // TODO pass latestVersion value to lib
+  storeVersionNumber();
+
   var fileUri =
     baseCDNURL + '/' + latestVersion + '/geckodriver-' + latestVersion;
   var DOWNLOAD_MAC = fileUri + '-macos.tar.gz';

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var baseCDNURL =
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');
 
-var latestVersion = 'v0.23.0';
+var latestVersion = 'v0.24.0';
 var downloadUrl;
 var outFile;
 var executable;

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -4,18 +4,25 @@ var path = require('path');
 process.env.PATH += path.delimiter + path.join(__dirname, '..');
 
 // support win32 vs other platforms
-exports.path = process.platform === 'win32' ? path.join(__dirname, '..', 'geckodriver.exe') : path.join(__dirname, '..', 'geckodriver');
+exports.path =
+  process.platform === 'win32'
+    ? path.join(__dirname, '..', 'geckodriver.exe')
+    : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-exports.version = '0.23.0';
+// TODO get cached value
+exports.version = '';
 
 exports.start = function(args) {
-  exports.defaultInstance = require('child_process').execFile(exports.path, args);
+  exports.defaultInstance = require('child_process').execFile(
+    exports.path,
+    args
+  );
   return exports.defaultInstance;
-}
+};
 
-exports.stop = function () {
-  if (exports.defaultInstance !== null){
+exports.stop = function() {
+  if (exports.defaultInstance !== null) {
     exports.defaultInstance.kill();
   }
-}
+};

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fs = require('fs');
 
 // add the geckodriver path to process PATH
 process.env.PATH += path.delimiter + path.join(__dirname, '..');
@@ -10,8 +11,7 @@ exports.path =
     : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-// TODO get cached value
-exports.version = '';
+exports.version = fs.readFileSync(path.join(__dirname, 'version'));
 
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "adm-zip": "0.4.11",
     "bluebird": "3.4.6",
     "got": "5.6.0",
-    "tar": "4.0.2",
-    "https-proxy-agent": "2.2.1"
+    "https-proxy-agent": "2.2.1",
+    "prettier": "^1.16.3",
+    "tar": "4.0.2"
   },
   "devDependencies": {
     "ava": "0.15.2"

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import child_process from 'child_process';
 test.cb('properly extracts', t => {
   child_process.exec('node ../index.js', (error, stdout, stderr) => {
     if (error) {
-      return t.fail(`exec error: ${error}`)
+      return t.fail(`exec error: ${error}`);
     }
     t.is(stdout, 'Downloading geckodriver... Extracting... Complete.\n');
     t.is(stderr, '');
@@ -13,6 +13,6 @@ test.cb('properly extracts', t => {
 });
 
 test('programmatic usage', t => {
-  var driver = require('../lib/geckodriver')
-  t.is(driver.version, '0.23.0')
+  var driver = require('../lib/geckodriver');
+  t.is(!!driver.version, true);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import child_process from 'child_process';
 
-test.cb('properly extracts', t => {
+test.cb.serial('properly extracts', t => {
   child_process.exec('node ../index.js', (error, stdout, stderr) => {
     if (error) {
       return t.fail(`exec error: ${error}`);
@@ -12,7 +12,7 @@ test.cb('properly extracts', t => {
   });
 });
 
-test('programmatic usage', t => {
+test.serial('programmatic usage', t => {
   var driver = require('../lib/geckodriver');
   t.is(!!driver.version, true);
 });


### PR DESCRIPTION
1. Made it so the `geckodriver` version number is fetched automatically. A hard-coded value is still provided, but only as a fallback if the lookup fails.

2. Added prettier for consistent styling across all files.