### PR TITLE
feat: support fixed version of geckodriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Default location is set to https://github.com/mozilla/geckodriver/releases/downl
 
 Use `HTTPS_PROXY` or `HTTP_PROXY` to set your proxy url.
 
+## Setting a specific version
+
+Use `GECKODRIVER_VERSION` if you require a specific version of gecko driver for your browser version.
+
 ## Related Projects
 
 * [node-chromedriver](https://github.com/giggio/node-chromedriver)

--- a/index.js
+++ b/index.js
@@ -15,14 +15,17 @@ var arch = os.arch();
 
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
 
+var version = process.env.GECKODRIVER_VERSION || '0.24.0';
+
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');
 
-var DOWNLOAD_MAC = baseCDNURL + '/v0.24.0/geckodriver-v0.24.0-macos.tar.gz';
-var DOWNLOAD_LINUX64 = baseCDNURL + '/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz';
-var DOWNLOAD_LINUX32 = baseCDNURL + '/v0.24.0/geckodriver-v0.24.0-linux32.tar.gz';
-var DOWNLOAD_WIN32 = baseCDNURL + '/v0.24.0/geckodriver-v0.24.0-win32.zip';
-var DOWNLOAD_WIN64 = baseCDNURL + '/v0.24.0/geckodriver-v0.24.0-win64.zip';
+var baseDownloadUrl =  baseCDNURL + '/v' + version + '/geckodriver-v' + version;
+var DOWNLOAD_MAC = baseDownloadUrl +'-macos.tar.gz';
+var DOWNLOAD_LINUX64 = baseDownloadUrl +'-linux64.tar.gz';
+var DOWNLOAD_LINUX32 = baseDownloadUrl +'-linux32.tar.gz';
+var DOWNLOAD_WIN32 = baseDownloadUrl +'-win32.zip';
+var DOWNLOAD_WIN64 = baseDownloadUrl +'-win64.zip';
 
 // TODO: move this to package.json or something
 var downloadUrl = DOWNLOAD_MAC;

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -7,7 +7,7 @@ process.env.PATH += path.delimiter + path.join(__dirname, '..');
 exports.path = process.platform === 'win32' ? path.join(__dirname, '..', 'geckodriver.exe') : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-exports.version = '0.24.0';
+exports.version =  process.env.GECKODRIVER_VERSION || '0.24.0';
 
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(exports.path, args);


### PR DESCRIPTION
Some of us are unfortunately in a corporate environment that locks down the version of applications. 

This PR adds the ability to specify via an environment variable which version of geckodriver to install. This method is similar to the method [chromedriver ](https://github.com/giggio/node-chromedriver/blob/master/install.js#L27) uses.