### PR TITLE
Allow specifying GECKODRIVER_FILEPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Use `HTTPS_PROXY` or `HTTP_PROXY` to set your proxy url.
 
 Use `GECKODRIVER_VERSION` if you require a specific version of gecko driver for your browser version.
 
+## Using a cached download
+
+Use `GECKODRIVER_FILEPATH` to point to a pre-downloaded geckodriver archive that should be extracted during installation.
+
 ## Related Projects
 
 * [node-chromedriver](https://github.com/giggio/node-chromedriver)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ if (platform === 'win32') {
   executable = 'geckodriver.exe';
 }
 
-if (!CACHED_ARCHIVE) {
+if (CACHED_ARCHIVE) {
   extract(CACHED_ARCHIVE);
 } else {
   process.stdout.write('Downloading geckodriver... ');

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var platform = os.platform();
 var arch = os.arch();
 
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
+var DOWNLOAD_FILEPATH = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 
 var version = process.env.GECKODRIVER_VERSION || '0.24.0';
 
@@ -49,21 +50,22 @@ if (platform === 'win32') {
   executable = 'geckodriver.exe';
 }
 
-process.stdout.write('Downloading geckodriver... ');
-got.stream(url.parse(downloadUrl), downloadOptions)
-  .pipe(fs.createWriteStream(outFile))
-  .on('close', function () {
-    process.stdout.write('Extracting... ');
-    extract(path.join(__dirname, outFile), __dirname)
-      .then(function () {
-        console.log('Complete.');
-      })
-      .catch(function (err) {
-        console.log('Something is wrong ', err.stack);
-      });
-  });
+if (!DOWNLOAD_FILEPATH) {
+  extract(DOWNLOAD_FILEPATH);
+} else {
+  process.stdout.write('Downloading geckodriver... ');
+  got.stream(url.parse(downloadUrl), downloadOptions)
+    .pipe(fs.createWriteStream(outFile))
+    .on('close', function () {
+      extract(path.join(__dirname, outFile));
+    });
+}
 
-function extract(archivePath, targetDirectoryPath) {
+
+function extract(archivePath) {
+  process.stdout.write('Extracting... ');
+  var targetDirectoryPath = __dirname;
+
   return new Promise(function (resolve, reject) {
     if (outFile.indexOf('.tar.gz') >= 0) {
       tar.extract({
@@ -87,5 +89,11 @@ function extract(archivePath, targetDirectoryPath) {
     } else {
       reject('This archive extension is not supported: ' + archivePath);
     }
+  })
+  .then(function () {
+    console.log('Complete.');
+  })
+  .catch(function (err) {
+    console.log('Something is wrong ', err.stack);
   });
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var platform = os.platform();
 var arch = os.arch();
 
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
-var DOWNLOAD_FILEPATH = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
+var CACHED_ARCHIVE = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 
 var version = process.env.GECKODRIVER_VERSION || '0.24.0';
 
@@ -50,8 +50,8 @@ if (platform === 'win32') {
   executable = 'geckodriver.exe';
 }
 
-if (!DOWNLOAD_FILEPATH) {
-  extract(DOWNLOAD_FILEPATH);
+if (!CACHED_ARCHIVE) {
+  extract(CACHED_ARCHIVE);
 } else {
   process.stdout.write('Downloading geckodriver... ');
   got.stream(url.parse(downloadUrl), downloadOptions)


### PR DESCRIPTION
We'd like to cache a version of the geckodriver archive because we've seen a number of failed postinstall script runs. Chromedriver supports this with the `CHROMEDRIVER_FILEPATH` environment flag, I was thinking it would make sense to add a `GECKODRIVER_FILEPATH` that points to the relevant filepath.