### PR TITLE
Upgrade tar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "adm-zip": "0.4.11",
     "bluebird": "3.4.6",
     "got": "5.6.0",
-    "tar": "4.0.2",
+    "tar": "4.4.2",
     "https-proxy-agent": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
https://www.npmjs.com/advisories/803

The version of `tar` in use has a security issue and thus fails `npm audit`.

This PR addresses that.