### PR TITLE
skip geckodriver download

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Use `GECKODRIVER_VERSION` if you require a specific version of gecko driver for 
 
 Use `GECKODRIVER_FILEPATH` to point to a pre-downloaded geckodriver archive that should be extracted during installation.
 
+## Skipping geckodriver download
+
+Use `GECKODRIVER_SKIP_DOWNLOAD` to skip the download of the geckodriver file.
+
+
 ## Related Projects
 
 * [node-chromedriver](https://github.com/giggio/node-chromedriver)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ var Promise = require('bluebird');
 var platform = os.platform();
 var arch = os.arch();
 
+var skipDownload = process.env.GECKODRIVER_SKIP_DOWNLOAD || process.env.npm_config_geckodriver_skip_download;
+if (skipDownload === 'true') {
+  console.log('Found GECKODRIVER_SKIP_DOWNLOAD variable, skipping installation.');
+  process.exit(0);
+}
+
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
 var CACHED_ARCHIVE = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 


### PR DESCRIPTION
Aligns behaviour with [chromedriver](https://github.com/giggio/node-chromedriver/blob/master/install.js#L13-L17). Needed for protected build environments where neither an official mirror is reachable nor a dedicated CDN is available.