### PR TITLE
update default driver version to 0.25.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if (skipDownload === 'true') {
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
 var CACHED_ARCHIVE = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 
-var version = process.env.GECKODRIVER_VERSION || '0.24.0';
+var version = process.env.GECKODRIVER_VERSION || '0.25.0';
 
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -7,7 +7,7 @@ process.env.PATH += path.delimiter + path.join(__dirname, '..');
 exports.path = process.platform === 'win32' ? path.join(__dirname, '..', 'geckodriver.exe') : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-exports.version =  process.env.GECKODRIVER_VERSION || '0.24.0';
+exports.version =  process.env.GECKODRIVER_VERSION || '0.25.0';
 
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(exports.path, args);

--- a/test/index.js
+++ b/test/index.js
@@ -14,5 +14,5 @@ test.cb('properly extracts', t => {
 
 test('programmatic usage', t => {
   var driver = require('../lib/geckodriver')
-  t.is(driver.version, '0.24.0')
+  t.is(driver.version, '0.25.0')
 });


### PR DESCRIPTION
New geckodriver 0.25.0 is [available](https://github.com/mozilla/geckodriver/releases/tag/v0.25.0). 
I tested it with Firefox 69.0.1 on Mac and do not see any issues.

@vladikoff I guess it should be under 1.17.x release?