### PR TITLE
update geckodriver to 0.26

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if (skipDownload === 'true') {
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
 var CACHED_ARCHIVE = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 
-var version = process.env.GECKODRIVER_VERSION || '0.25.0';
+var version = process.env.GECKODRIVER_VERSION || '0.26.0';
 
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -7,7 +7,7 @@ process.env.PATH += path.delimiter + path.join(__dirname, '..');
 exports.path = process.platform === 'win32' ? path.join(__dirname, '..', 'geckodriver.exe') : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-exports.version =  process.env.GECKODRIVER_VERSION || '0.25.0';
+exports.version =  process.env.GECKODRIVER_VERSION || '0.26.0';
 
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(exports.path, args);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geckodriver",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geckodriver",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Downloader for https://github.com/mozilla/geckodriver/releases",
   "scripts": {
     "test": "ava",

--- a/test/index.js
+++ b/test/index.js
@@ -14,5 +14,5 @@ test.cb('properly extracts', t => {
 
 test('programmatic usage', t => {
   var driver = require('../lib/geckodriver')
-  t.is(driver.version, '0.25.0')
+  t.is(driver.version, '0.26.0')
 });


### PR DESCRIPTION
New geckodriver v [0.26.0](https://github.com/mozilla/geckodriver/releases/tag/v0.26.0) was released.

Tested on MacOS 10.14.6