### PR TITLE
fix: Update proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var outFile = 'geckodriver.tar.gz';
 var executable = 'geckodriver';
 
 var downloadOptions = {}
-var proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || null;
+var proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy || null;
 if (proxy !== null) {
   downloadOptions.agent = new proxyAgent(proxy);
 }


### PR DESCRIPTION
In some environment, it use `https_proxy` and `http_proxy` instead.
In this case, it will fail in the download process.