### PR TITLE
bump default binary to 0.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Use `GECKODRIVER_SKIP_DOWNLOAD` to skip the download of the geckodriver file.
 ## Versions
 
 * [npm module version] - [geckodriver version]
+* 1.22.x - geckodriver 0.29.0
 * 1.21.x - geckodriver 0.28.0
 * 1.20.x - geckodriver 0.27.0
 * 1.19.x - geckodriver 0.26.0

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if (skipDownload === 'true') {
 var baseCDNURL = process.env.GECKODRIVER_CDNURL || process.env.npm_config_geckodriver_cdnurl || 'https://github.com/mozilla/geckodriver/releases/download';
 var CACHED_ARCHIVE = process.env.GECKODRIVER_FILEPATH ? path.resolve(process.env.GECKODRIVER_FILEPATH) : undefined;
 
-var version = process.env.GECKODRIVER_VERSION || process.env.npm_config_geckodriver_version || '0.28.0';
+var version = process.env.GECKODRIVER_VERSION || process.env.npm_config_geckodriver_version || '0.29.0';
 
 // Remove trailing slash if included
 baseCDNURL = baseCDNURL.replace(/\/+$/, '');

--- a/lib/geckodriver.js
+++ b/lib/geckodriver.js
@@ -7,7 +7,7 @@ process.env.PATH += path.delimiter + path.join(__dirname, '..');
 exports.path = process.platform === 'win32' ? path.join(__dirname, '..', 'geckodriver.exe') : path.join(__dirname, '..', 'geckodriver');
 
 // specify the version of geckodriver
-exports.version =  process.env.GECKODRIVER_VERSION || '0.28.0';
+exports.version =  process.env.GECKODRIVER_VERSION || '0.29.0';
 
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(exports.path, args);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geckodriver",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Downloader for https://github.com/mozilla/geckodriver/releases",
   "scripts": {
     "test": "ava",

--- a/test/index.js
+++ b/test/index.js
@@ -14,5 +14,5 @@ test.cb('properly extracts', t => {
 
 test('programmatic usage', t => {
   var driver = require('../lib/geckodriver')
-  t.is(driver.version, '0.28.0')
+  t.is(driver.version, '0.29.0')
 });


### PR DESCRIPTION
Adding the latest [0.29.0](https://github.com/mozilla/geckodriver/releases/tag/v0.29.0) release