### PR TITLE
Bump adm-zip from 0.4.16 to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,9 +172,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.3.tgz",
+      "integrity": "sha512-zsoTXEwRNCxBzRHLENFLuecCcwzzXiEhWo1r3GP68iwi8Q/hW2RrqgeY1nfJ/AhNQNWnZq/4v0TbfMsUkI+TYw=="
     },
     "agent-base": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/vladikoff/node-geckodriver#readme",
   "dependencies": {
-    "adm-zip": "0.4.16",
+    "adm-zip": "0.5.3",
     "bluebird": "3.7.2",
     "got": "5.6.0",
     "tar": "6.0.2",


### PR DESCRIPTION
Version 0.4.16 of apm-zip had a security vulnerability, see: https://app.snyk.io/vuln/SNYK-JS-ADMZIP-1065796