### PR TITLE
fix post install script about execution error in proxy environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var executable = 'geckodriver';
 var downloadOptions = {}
 var proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy || null;
 if (proxy !== null) {
-  downloadOptions.agent = new proxyAgent(proxy);
+  downloadOptions.agent = {https: new proxyAgent(proxy)};
 }
 
 if (platform === 'linux') {


### PR DESCRIPTION
Some explanation about why it would work in case you're confused by Got's document

In Got's readme it gives two example about setting proxy.

- using "tunnel"

`
await got('https://sindresorhus.com', {
	agent: {
		https: tunnel.httpsOverHttp({
			proxy: {
				host: 'localhost'
			}
		})
	}
});
`

- or hpagent

`
await got('https://sindresorhus.com', {
	agent: {
		https: new HttpsProxyAgent({
			keepAlive: true,
			keepAliveMsecs: 1000,
			maxSockets: 256,
			maxFreeSockets: 256,
			scheduling: 'lifo',
			proxy: 'https://localhost:8080'
		})
	}
});
`

But meanwhile if you check the ["agent"](https://github.com/sindresorhus/got#agent) chapter
it says
```md
agent
Type: object

An object representing http, https and http2 keys for **http.Agent, https.Agent** and http2wrapper.Agent **instance**.
```
So the current proxy agent ["'https-proxy-agent'"](virtual-services-china.ext.nokia.com/vpn/index.html) used by geckodriver 
is actually feasible for "Got" as it's already a "http.Agent implementation"